### PR TITLE
Fix empty mounted volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk --no-cache --update \
     add apache2 \
     apache2-ssl \
     curl \
+    jq \
+    7zip \
     php83-apache2 \
     php83-bcmath \
     php83-bz2 \
@@ -38,7 +40,14 @@ RUN apk --no-cache --update \
     tzdata \
     && mkdir /htdocs
 
-COPY linkstack /htdocs
+RUN TAG=$(curl -s https://api.github.com/repos/LinkStackOrg/LinkStack/releases/latest | jq -r .tag_name) && \
+    curl -L -o linkstack.zip \
+      "https://github.com/LinkStackOrg/LinkStack/releases/download/${TAG}/linkstack.zip" && \
+    7z x linkstack.zip -o/linkstack && \
+    cp -r /linkstack /htdocs && \
+    rm linkstack.zip
+
+
 COPY configs/apache2/httpd.conf /etc/apache2/httpd.conf
 COPY configs/apache2/ssl.conf /etc/apache2/conf.d/ssl.conf
 COPY configs/php/php.ini /etc/php83/conf.d/40-custom.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN TAG=$(curl -s https://api.github.com/repos/LinkStackOrg/LinkStack/releases/l
     curl -L -o linkstack.zip \
       "https://github.com/LinkStackOrg/LinkStack/releases/download/${TAG}/linkstack.zip" && \
     7z x linkstack.zip -o/linkstack && \
-    cp -r /linkstack /htdocs && \
+    cp -ar /linkstack/linkstack/. /htdocs && \
     rm linkstack.zip
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 <a name="1"></a>
 ## About
 
-The official docker version of [LinkStack](https://github.com/linkstackorg/linkstack). This docker image is a simple to set up solution, containing everything you need to run LinkStack.
+The official docker version of [LinkStack](https://github.com/linkstackorg/linkstack). This docker image is a simple to set up solution, containing everything you need to run LinkStack, plus a copy of the latest release of LinkStack.
 
 The docker version of LinkStack retains all the features and customization options of the [original version](https://github.com/linkstackorg/linkstack).
 
@@ -179,6 +179,7 @@ Example config.
 ```yml
 services:
   linkstack:
+    container_name: linkstack
     hostname: 'linkstack'
     image: 'linkstackorg/linkstack:latest'
     environment:
@@ -225,13 +226,17 @@ This updater allows you to update your installation with just one click.
 
 **If you wish to build or modify your own docker version of LinkStack, you can do so with the instructions below:**
 
-- Download this GitHub repository as well as the latest release of LinkStack from [here](https://github.com/linkstackorg/linkstack/releases/latest/download/linkstack.zip).
-- Place the downloaded release files directly into the linkstack folder from [this repository](https://github.com/linkstackorg/linkstack-docker/archive/refs/heads/main.zip).
+- Download this GitHub repository.  
+- Use he included docker-compose.yml to run the stack.  
 
-From the docker directory, run the command:
-<pre>
-docker build -t linkstack .
-</pre>You can now set up your application on your defined ports.
+
+```bash
+$ git clone https://github.com/LinkStackOrg/linkstack-docker.git
+$ cd linkstack-docker
+$ chown -R 100:101 ./linkstack # Required as the container runs with permissions for apache:apache
+$ docker compose up -d --build
+```
+You can now set up your application on your defined ports.
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Both HTTP and HTTPS are supported and exposed by default.
 
 <br>
 
-<pre>
+```bash
 docker run --detach \
     --name linkstack \
     --publish 80:80 \
@@ -147,13 +147,13 @@ docker run --detach \
     --restart unless-stopped \
     --mount source=linkstack,target=/htdocs \
     linkstackorg/linkstack
-</pre>
+```
 
 <br>
 
 #### Custom deployment
 
-<pre>
+```bash
 docker run --detach \
     --name linkstack \
     --hostname linkstack \
@@ -168,7 +168,7 @@ docker run --detach \
     --restart unless-stopped \
     --mount source=linkstack,target=/htdocs \
     linkstackorg/linkstack
-</pre>
+```
 
 <br>
 
@@ -176,11 +176,8 @@ docker run --detach \
 <ins>Use HTTPS for your reverse proxy to avoid issues</ins><br>
 Example config.
 
-<pre>
-version: "3.8"
-
+```yml
 services:
-
   linkstack:
     hostname: 'linkstack'
     image: 'linkstackorg/linkstack:latest'
@@ -195,12 +192,13 @@ services:
     volumes:
       - 'linkstack_data:/htdocs'
     ports:
+      - '8180:80'
       - '8190:443'
     restart: unless-stopped
 
 volumes:
   linkstack_data:
-</pre>
+```
 
 <br>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
-version: "3.8"
-
 services:
   linkstack:
+    container_name: linkstack
     hostname: 'linkstack'
-    image: 'linkstackorg/linkstack:latest'
+    # image: 'linkstackorg/linkstack:latest'
+    build:
+      context: .
+      dockerfile: Dockerfile
     environment:
       TZ: 'Europe/Berlin'
       SERVER_ADMIN: 'admin@example.com'
@@ -13,20 +15,20 @@ services:
       PHP_MEMORY_LIMIT: '256M'
       UPLOAD_MAX_FILESIZE: '8M'
     volumes:
-      - '/htdocs'
+      - './linkstack:/htdocs'
     ports:
-      - '8080:80'
-      - '8081:443'
+      - '8190:80'
+      - '8191:443'
     restart: unless-stopped
     user: apache:apache
     # read_only: true
-    depends_on:
-      - mysql
-    links:
-      - mysql
-  mysql:
-    image: mysql:8
-    environment:
-        MYSQL_ROOT_PASSWORD: xeFgUGb5mPPn5q2d
-    ports:
-        - 3306:3306
+  #   depends_on: # Uncomment from here to use MySQL instead of SQLite
+  #     - mysql
+  #   links:
+  #     - mysql
+  # mysql:
+  #   image: mysql:8
+  #   environment:
+  #       MYSQL_ROOT_PASSWORD: xeFgUGb5mPPn5q2d
+  #   ports:
+  #       - 3306:3306

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,8 +19,8 @@ export UPLOAD_MAX_FILESIZE="${UPLOAD_MAX_FILESIZE:-8M}"
 # When version.json has CR/LF, it fx up, so have to add tr to remove the line endings.
 v="$(cat /htdocs/version.json | tr -d '\r\n')"
 
-if [ -z "$v"]; then
-	cp -r /linkstack/linkstack/* /htdocs
+if [ -z "$v" ]; then
+	cp -ar /linkstack/linkstack/. /htdocs
 	v="$(cat /htdocs/version.json | tr -d '\r\n')"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,11 @@ export UPLOAD_MAX_FILESIZE="${UPLOAD_MAX_FILESIZE:-8M}"
 # When version.json has CR/LF, it fx up, so have to add tr to remove the line endings.
 v="$(cat /htdocs/version.json | tr -d '\r\n')"
 
+if [ -z "$v"]; then
+	cp -r /linkstack/linkstack/* /htdocs
+	v="$(cat /htdocs/version.json | tr -d '\r\n')"
+fi
+
 # Calc length of whitespace we need, based on version length.
 vlen="$((27-${#v}))"
 


### PR DESCRIPTION
Fixes #112, #162  
Helps on #137  

- Users don't have to manually download LinkStack (it should be included by default, being the official container)  
- If user mounts `/htdocs` the container automatically sets up LinkStack.  